### PR TITLE
兼容旧的api

### DIFF
--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -101,7 +101,9 @@ var respond = function (handler) {
           var list = List.get(req.wxsession._wait);
           var handle = list.get(message.Content);
           var wrapper = function (message) {
-            return function (info, req, res) {
+            return handler.handle ? function(req, res) {
+              res.reply(message);
+            } : function (info, req, res) {
               res.reply(message);
             };
           };
@@ -130,7 +132,6 @@ var respond = function (handler) {
             req.wxsession.save();
           }
         };
-
         // 等待列表
         res.wait = function (name) {
           var list = List.get(name);

--- a/test/list.test2.js
+++ b/test/list.test2.js
@@ -1,0 +1,63 @@
+require('should');
+var List = require('../').List;
+
+var querystring = require('querystring');
+var request = require('supertest');
+var template = require('./support').template;
+var tail = require('./support').tail;
+
+var connect = require('connect');
+var wechat = require('../');
+
+var app = connect();
+app.use(connect.query());
+app.use(connect.cookieParser());
+app.use(connect.session({secret: 'keyboard cat', cookie: {maxAge: 60000}}));
+app.use('/wechat', wechat('some token', function (req, res, next) {
+  // 微信输入信息都在req.weixin上
+  var info = req.weixin;
+  if (info.Content === 'list') {
+    res.wait('view');
+  }
+}));
+
+describe('list', function() {
+  it('should ok with list', function (done) {
+    List.add('view', [
+      ['回复{c}查看我的性取向', '这样的事情怎么好意思告诉你啦- -']
+    ]);
+    // console.log(JSON.stringify(List.get('view')));
+    var info = {
+      sp: 'test',
+      user: 'test',
+      type: 'text',
+      text: 'list'
+    };
+
+    request(app)
+    .post('/wechat' + tail())
+    .send(template(info))
+    .expect(200)
+    .end(function(err, res){
+      if (err) return done(err);
+      done();
+
+      info = {
+        sp: 'test',
+        user: 'test',
+        type: 'text',
+        text: 'c'
+      };
+
+      request(app)
+      .post('/wechat' + tail())
+      .send(template(info))
+      .expect(200)
+      .end(function(err, res){
+        if (err) return done(err);
+        var body = res.text.toString();
+        body.should.include('这样的事情怎么好意思告诉你啦');
+      });
+    });
+  });
+});


### PR DESCRIPTION
使用旧的handle风格的api时，当list item第二项为字符串时比如
List.add('view', [
      ['回复{c}查看我的性取向', '这样的事情怎么好意思告诉你啦- -']
    ]);，
此时在wechat.js的done方法中的wrapper函数，应该返回兼容旧的api的callback
