### PR TITLE
可能因为formstream版本更新导致了一个bug

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -908,9 +908,6 @@ API.prototype._uploadMedia = function (filepath, type, callback) {
     }
     var form = formstream();
     form.file('media', filepath, path.basename(filepath), stat.size);
-    form.headers({
-      'Content-Type': 'application/json'
-    });
     var url = that.fileServerPrefix + 'media/upload?access_token=' + that.token + '&type=' + type;
     var opts = {
       dataType: 'json',


### PR DESCRIPTION
uploadMedia中：

```
form.headers({
  'Content-Type': 'application/json'
});
```

这个操作好像是没有作用？
另外在formstream（0.0.8）中重复调用`formstream.prototype.headers`导致Content-length增加，因而向微信服务器的请求会超时。
