### PR TITLE
fix 根据openid列表群发 API

### DIFF
--- a/lib/api_mass_send.js
+++ b/lib/api_mass_send.js
@@ -152,15 +152,18 @@ exports.massSend = function (opts, receivers, callback) {
  * 群发消息的未封装版本
  */
 exports._massSend = function (opts, receivers, callback) {
+  var url;
   if (Array.isArray(receivers)) {
     opts.touser = receivers;
+    url = this.prefix + 'message/mass/send?access_token=' + this.token.accessToken;
   } else {
     opts.filter = {
       "group_id": receivers
     };
+    url = this.prefix + 'message/mass/sendall?access_token=' + this.token.accessToken;
   }
   // https://api.weixin.qq.com/cgi-bin/message/mass/sendall?access_token=ACCESS_TOKEN
-  var url = this.prefix + 'message/mass/sendall?access_token=' + this.token.accessToken;
+//  var url = this.prefix + 'message/mass/sendall?access_token=' + this.token.accessToken;
   urllib.request(url, postJSON(opts), wrapper(callback));
 };
 


### PR DESCRIPTION
微信群发api根据分组发送：https://api.weixin.qq.com/cgi-bin/message/mass/sendall?access_token=ACCESS_TOKEN
根据openid列表发送：https://api.weixin.qq.com/cgi-bin/message/mass/send?access_token=ACCESS_TOKEN

这是两个不同的API
