### PR TITLE
修复响应视频消息的模板，增加指定客服人员转发多客服消息

### DIFF
--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -62,9 +62,9 @@ var tpl = ['<xml>',
       '<Description><![CDATA[<%-content.description%>]]></Description>',
     '</Video>',
   '<% } else if (msgType === "transfer_customer_service") { %>',
-    '<% if (content && (content.kfAccount || content.KfAccount)) { %>',
+    '<% if (content && content.kfAccount) { %>',
       '<TransInfo>',
-        '<KfAccount><%-content.kfAccount || content.KfAccount%></KfAccount>',
+        '<KfAccount><%-content.kfAccount%></KfAccount>',
       '</TransInfo>',
     '<% } %>',
   '<% } else { %>',
@@ -117,8 +117,7 @@ var formatMessage = function (result) {
 var reply = function (content, fromUsername, toUsername) {
   var info = {};
   var type = 'text';
-  if (!content) return ''; // 支持 res.reply() 回复空字符串给微信服务器以免其发起重试
-  info.content = content;
+  info.content = content || '';
   if (Array.isArray(content)) {
     type = 'news';
   } else if (typeof content === 'object') {
@@ -143,7 +142,7 @@ var reply2CustomerService = function (kfAccount, fromUsername, toUsername) {
   info.toUsername = toUsername;
   info.fromUsername = fromUsername;
   info.content = {};
-  if (typeof kfAccount === 'string') info.content.KfAccount = kfAccount;
+  if (typeof kfAccount === 'string') info.content.kfAccount = kfAccount;
   return compiled(info);
 };
 
@@ -159,6 +158,7 @@ var respond = function (handler) {
       req.weixin = message;
       res.reply = function (content) {
         res.writeHead(200);
+        if (!content) return res.end('');
         res.end(reply(content, message.ToUserName, message.FromUserName));
       };
 

--- a/test/wechat.test.js
+++ b/test/wechat.test.js
@@ -30,6 +30,8 @@ app.use('/wechat', wechat('some token', function (req, res, next) {
     });
   } else if (info.FromUserName === 'cs') {
     res.transfer2CustomerService();
+  } else if (info.FromUserName === 'kf') {
+    res.transfer2CustomerService('test1@test');
   } else {
   // 回复高富帅(图文回复)
     res.reply([
@@ -246,6 +248,31 @@ describe('wechat.js', function () {
         done();
       });
     });
+
+
+    it('should ok with transfer info to kfAccount', function(done) {
+      var info = {
+        sp: 'zhong',
+        user: 'kf',
+        type: 'text',
+        text: '测试中'
+      };
+      request(app)
+      .post('/wechat' + tail())
+      .send(template(info))
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        var body = res.text.toString();
+        body.should.include('<ToUserName><![CDATA[kf]]></ToUserName>');
+        body.should.include('<FromUserName><![CDATA[zhong]]></FromUserName>');
+        body.should.match(/<CreateTime>\d{13}<\/CreateTime>/);
+        body.should.include('<MsgType><![CDATA[transfer_customer_service]]></MsgType>');
+        body.should.include('<KfAccount>test1@test</KfAccount>');
+        done();
+      });
+    });
+
 
     it('should pass to next', function (done) {
       var info = {


### PR DESCRIPTION
1. 修复被动响应视频消息的模板。官方文档链接： http://mp.weixin.qq.com/wiki/index.php?title=%E5%8F%91%E9%80%81%E8%A2%AB%E5%8A%A8%E5%93%8D%E5%BA%94%E6%B6%88%E6%81%AF#.E5.9B.9E.E5.A4.8D.E8.A7.86.E9.A2.91.E6.B6.88.E6.81.AF
2. 增加转发客服消息至指定客服人员。官方文档链接： http://dkf.qq.com/document-4_1.html#anchor-msg_specify
