### PR TITLE
support content-type "text/xml"

### DIFF
--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -88,6 +88,14 @@ var wrapTpl = '<xml>' +
 var encryptWrap = ejs.compile(wrapTpl);
 
 var load = function (stream, callback) {
+  // support content-type 'text/xml' using 'express-xml-bodyparser', which set raw xml string 
+  // to 'req.rawBody'(while latest body-parser no longer set req.rawBody), see
+  // https://github.com/macedigital/express-xml-bodyparser/blob/master/lib/types/xml.js#L79
+  if(stream.rawBody) {
+    callback(null, stream.rawBody);
+    return;
+  }
+
   var buffers = [];
   stream.on('data', function (trunk) {
     buffers.push(trunk);
@@ -97,12 +105,6 @@ var load = function (stream, callback) {
   });
   stream.once('error', callback);
 
-  // support content-type 'text/xml' using 'express-xml-bodyparser', which set raw xml string 
-  // to 'req.rawBody'(while latest body-parser no longer set req.rawBody), see
-  // https://github.com/macedigital/express-xml-bodyparser/blob/master/lib/types/xml.js#L79
-  if(stream.rawBody) {
-    callback(null, stream.rawBody);
-  }
 };
 
 /*!

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -96,6 +96,13 @@ var load = function (stream, callback) {
     callback(null, Buffer.concat(buffers));
   });
   stream.once('error', callback);
+
+  // support content-type 'text/xml' using 'express-xml-bodyparser', which set raw xml string 
+  // to 'req.rawBody'(while latest body-parser no longer set req.rawBody), see
+  // https://github.com/macedigital/express-xml-bodyparser/blob/master/lib/types/xml.js#L79
+  if(stream.rawBody) {
+    callback(null, stream.rawBody);
+  }
 };
 
 /*!

--- a/test/wechat.test.js
+++ b/test/wechat.test.js
@@ -153,6 +153,36 @@ describe('wechat.js', function () {
       });
     });
 
+    /*
+    it('should ok with req.rawBody', function (done) {
+      var rawBody = {
+        rawBody: {
+          ToUserName: 'nvshen',
+          FromUserName: 'diaosi',
+          CreateTime: '' + new Date().getTime(),
+          MsgType: 'text',
+          Content: '测试中'
+        }
+      };
+
+      request(app)
+      .post('/wechat'+tail())
+      .send({})
+      .expect(200, done);
+      //.expect(200)
+      //.end(function(err, res){
+      //  if (err) return done(err);
+      //  var body = res.text.toString();
+      //  body.should.include('<ToUserName><![CDATA[diaosi]]></ToUserName>');
+      //  body.should.include('<FromUserName><![CDATA[nvshen]]></FromUserName>');
+      //  body.should.match(/<CreateTime>\d{13}<\/CreateTime>/);
+      //  body.should.include('<MsgType><![CDATA[text]]></MsgType>');
+      //  body.should.include('<Content><![CDATA[hehe]]></Content>');
+      //  done();
+      //});
+    });
+    */
+
     it('should ok with text type object', function (done) {
       var info = {
         sp: 'nvshen',


### PR DESCRIPTION
try fix #164
the default sails http middleware seems not work with 'text/xml' post request well and result error in req, which not fire [load](https://github.com/node-webot/wechat/blob/master/lib/wechat.js#L90) function at all.

after debug, there are two way to fix this:

1. parser `req.weixin` in a middleware before invoke wechat, since wechat will use it directly if find [it](https://github.com/node-webot/wechat/blob/master/lib/wechat.js#L422).

2. override sails body-parse using `express-xml-bodyparser` then use the result in load.

this PR implement 2.

thanks.
