### PR TITLE
处理回复设备消息为二进制数据时乱码的问题.

### DIFF
--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -191,7 +191,10 @@ var reply = function (content, fromUsername, toUsername, message) {
       delete info.content;
       info.DeviceStatus = isNaN(content) ? 0 : content;
     } else {
-      info.content = new Buffer(String(content)).toString('base64');
+      if (!(content instanceof Buffer)) {
+        content = String(content);
+      }
+      info.content = new Buffer(content).toString('base64');
     }
     type = message.MsgType;
     if (message.MsgType === 'device_event') {


### PR DESCRIPTION
Buffer强转为string时,非ascii字符可能会变乱码,此时不应强转string.