### PR TITLE
Support restify

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -120,8 +120,10 @@ var load = function (stream, callback) {
   // to 'req.rawBody'(while latest body-parser no longer set req.rawBody), see
   // https://github.com/macedigital/express-xml-bodyparser/blob/master/lib/types/xml.js#L79
   // support restify req.body
-  if (stream.rawBody||stream.body) {
-    callback(null, stream.rawBody||stream.body);
+
+  var body = stream.rawBody || stream.body;
+  if (body) {
+    callback(null, body);
     return;
   }
 

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -119,8 +119,9 @@ var load = function (stream, callback) {
   // support content-type 'text/xml' using 'express-xml-bodyparser', which set raw xml string
   // to 'req.rawBody'(while latest body-parser no longer set req.rawBody), see
   // https://github.com/macedigital/express-xml-bodyparser/blob/master/lib/types/xml.js#L79
-  if (stream.rawBody) {
-    callback(null, stream.rawBody);
+  // support restify req.body
+  if (stream.rawBody||stream.body) {
+    callback(null, stream.rawBody||stream.body);
     return;
   }
 


### PR DESCRIPTION
支持 restify 框架

ex:
var restify = require('restify');
var server = restify.createServer({});
server.use(restify.acceptParser(server.acceptable));
server.use(restify.queryParser());
server.use(restify.bodyParser());
server.post('/', wechat(config.wx,function(req,res,next){
        console.log(req.weixin);
        res.send('success');
}));