### PR TITLE
wxsession does not support express-mysql-session

### DIFF
--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -340,6 +340,11 @@ var respond = function (handler) {
           req.wxsession = new Session(openid, req);
           req.wxsession.cookie = req.session.cookie;
         } else {
+          // add by xjmalm, convert string type to Date in case some of the session storage only stores the simple data types
+          if (session.cookie && 'string' === typeof session.cookie.expires) {
+            session.cookie.expires = new Date(session.cookie.expires);
+          }
+
           req.wxsession = new Session(openid, req, session);
         }
         done();


### PR DESCRIPTION
After getting the session from session storage, if the session.cookie.expires is string type, convert the string type to Date in case some of the session storage only stores the simple data types.