### PR TITLE
xml2js解析出来的对象转换成直接可访问的对象

### DIFF
--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -172,8 +172,10 @@ var formatMessage = function (result) {
         });
       }
     }
+    return message;
+  } else {
+    return result;
   }
-  return message;
 };
 
 /*!

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -5,6 +5,12 @@ var tail = require('./support').tail;
 
 var connect = require('connect');
 var wechat = require('../');
+var assert = require('assert');
+var xml2js = require('xml2js');
+var rewire = require("rewire");
+var wechatModule = rewire('../lib/wechat.js');
+
+var formatMessage = wechatModule.__get__('formatMessage')
 
 var app = connect();
 app.use(connect.query());
@@ -39,4 +45,19 @@ describe('parse_xml.js', function () {
     .expect('BadMessageError')
     .end(done);
   });
+
+  it('should return array when xml include repeat item', function(done) {
+    var xml = '<xml><arraytest><item><![CDATA[item0]]></item><item><![CDATA[item1]]></item></arraytest></xml>';
+    xml2js.parseString(xml, {trim: true}, function(err, result) {
+      var xml = formatMessage(result.xml);
+      var items = xml['arraytest']['item'];
+
+      assert((items instanceof Array) == true);
+      for(var i = 0; i < items.length; i++) {
+        assert(items[i] == ("item"+i));
+      }
+
+      done()
+    });
+  })
 });


### PR DESCRIPTION
xml2js解析出来的对象转换成直接可访问的对象应该加上如果不是对象的情况,虽然微信的xml数据没有这种情况，个人觉得还是应该处理下比较好