### PR TITLE
Add configuration to disable signature check

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -153,7 +153,8 @@ var wechat = require('wechat');
 var config = {
   token: 'token',
   appid: 'appid',
-  encodingAESKey: 'encodinAESKey'
+  encodingAESKey: 'encodinAESKey',
+  checkSignature: true // optional, default value is true. Because WeChat open platform debug tool does not send signature in plaintext mode, if you want to use this debug tool, please set to false
 };
 
 app.use(express.query());

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ var wechat = require('wechat');
 var config = {
   token: 'token',
   appid: 'appid',
-  encodingAESKey: 'encodinAESKey'
+  encodingAESKey: 'encodinAESKey',
+  checkSignature: true // 可选，默认为true。由于微信公众平台接口调试工具在明文模式下不发送签名，所以如要使用该测试工具，请将其设置为false
 };
 
 app.use(express.query());
@@ -163,7 +164,8 @@ var wechat = require('wechat');
 var config = {
   token: 'token',
   appid: 'appid',
-  encodingAESKey: 'encodinAESKey'
+  encodingAESKey: 'encodinAESKey',
+  checkSignature: true // 可选，默认为true。由于微信公众平台接口调试工具在明文模式下不发送签名，所以如要使用该测试工具，请将其设置为false
 };
 
 app.use(express.query());

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -506,7 +506,7 @@ Handler.prototype.middlewarify = function () {
     } else {
       var method = req.method;
       // 动态token，在前置中间件中设置该值req.wechat_token，优先选用
-      if (this.checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
+      if (that.checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
         res.writeHead(401);
         res.end('Invalid signature');
         return;

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -505,6 +505,7 @@ Handler.prototype.middlewarify = function () {
       serveEncrypt(that, req, res, next, _respond);
     } else {
       var method = req.method;
+      console.log('checkSignature: ' + that.checkSignature);
       // 动态token，在前置中间件中设置该值req.wechat_token，优先选用
       if (that.checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
         res.writeHead(401);

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -501,11 +501,15 @@ Handler.prototype.middlewarify = function () {
       return;
     }
     if (req.query.encrypt_type && req.query.msg_signature) {
+      console.log('serveEncrypt')
       serveEncrypt(that, req, res, next, _respond);
     } else {
+      console.log('not encrypt')
+      console.log('check signature: ' + this.checkSignature)
       var method = req.method;
       // 动态token，在前置中间件中设置该值req.wechat_token，优先选用
-      if (checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
+      if (this.checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
+        console.log('inside check signature')
         res.writeHead(401);
         res.end('Invalid signature');
         return;

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -378,7 +378,11 @@ Handler.prototype.setToken = function (token) {
     this.token = token.token;
     this.appid = token.appid;
     this.encodingAESKey = token.encodingAESKey;
-    this.checkSignature = token.checkSignature || true;
+    if (typeof token.checkSignature === 'undefined' || typeof token.checkSignature !== 'boolean') {
+      this.checkSignature = true;
+    } else {
+      this.checkSignature = token.checkSignature
+    }
   }
 };
 
@@ -505,7 +509,6 @@ Handler.prototype.middlewarify = function () {
       serveEncrypt(that, req, res, next, _respond);
     } else {
       var method = req.method;
-      console.log('checkSignature: ' + that.checkSignature);
       // 动态token，在前置中间件中设置该值req.wechat_token，优先选用
       if (that.checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
         res.writeHead(401);

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -488,6 +488,7 @@ var serveEncrypt = function (that, req, res, next, _respond) {
  * 根据Handler对象生成响应方法，并最终生成中间件函数
  */
 Handler.prototype.middlewarify = function () {
+  console.log('middlewarify')
   var that = this;
   if (this.encodingAESKey) {
     that.cryptor = new WXBizMsgCrypt(this.token, this.encodingAESKey, this.appid);
@@ -580,6 +581,7 @@ Handler.prototype.middlewarify = function () {
  * @param {Function} handle 生成的回调函数，参见示例
  */
 var middleware = function (token, handle) {
+  console.log('middleware')
   if (arguments.length === 1) {
     return new Handler(token);
   }

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -373,6 +373,7 @@ var Handler = function (token, handle) {
 Handler.prototype.setToken = function (token) {
   if (typeof token === 'string') {
     this.token = token;
+    this.checkSignature = true;
   } else {
     this.token = token.token;
     this.appid = token.appid;

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -488,7 +488,6 @@ var serveEncrypt = function (that, req, res, next, _respond) {
  * 根据Handler对象生成响应方法，并最终生成中间件函数
  */
 Handler.prototype.middlewarify = function () {
-  console.log('middlewarify')
   var that = this;
   if (this.encodingAESKey) {
     that.cryptor = new WXBizMsgCrypt(this.token, this.encodingAESKey, this.appid);
@@ -502,15 +501,11 @@ Handler.prototype.middlewarify = function () {
       return;
     }
     if (req.query.encrypt_type && req.query.msg_signature) {
-      console.log('serveEncrypt')
       serveEncrypt(that, req, res, next, _respond);
     } else {
-      console.log('not encrypt')
-      console.log('check signature: ' + this.checkSignature)
       var method = req.method;
       // 动态token，在前置中间件中设置该值req.wechat_token，优先选用
       if (this.checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
-        console.log('inside check signature')
         res.writeHead(401);
         res.end('Invalid signature');
         return;
@@ -581,7 +576,6 @@ Handler.prototype.middlewarify = function () {
  * @param {Function} handle 生成的回调函数，参见示例
  */
 var middleware = function (token, handle) {
-  console.log('middleware')
   if (arguments.length === 1) {
     return new Handler(token);
   }

--- a/lib/wechat.js
+++ b/lib/wechat.js
@@ -377,6 +377,7 @@ Handler.prototype.setToken = function (token) {
     this.token = token.token;
     this.appid = token.appid;
     this.encodingAESKey = token.encodingAESKey;
+    this.checkSignature = token.checkSignature || true;
   }
 };
 
@@ -504,7 +505,7 @@ Handler.prototype.middlewarify = function () {
     } else {
       var method = req.method;
       // 动态token，在前置中间件中设置该值req.wechat_token，优先选用
-      if (!checkSignature(req.query, req.wechat_token || token)) {
+      if (checkSignature && !checkSignature(req.query, req.wechat_token || token)) {
         res.writeHead(401);
         res.end('Invalid signature');
         return;


### PR DESCRIPTION
Since WeChat debug tool does not send signature in plaintext mode, it will fail while checking signature. This new option can disable signature checking so developers can use WeChat debug tool to debug their code.